### PR TITLE
Add dual-zone bed UI component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import styles from "./page.module.css";
+import BedDualZone from "@/components/BedDualZone";
 
 export default function Home() {
   return (
@@ -19,6 +20,13 @@ export default function Home() {
           </li>
           <li>Save and see your changes instantly.</li>
         </ol>
+
+        <BedDualZone
+          leftStatus="heating"
+          rightStatus="cooling"
+          selectedSide="left"
+          editingSide="right"
+        />
 
         <div className={styles.ctas}>
           <a

--- a/src/components/BedDualZone.module.css
+++ b/src/components/BedDualZone.module.css
@@ -1,0 +1,39 @@
+.bed {
+  display: flex;
+  width: 200px;
+  height: 100px;
+  border: 1px solid #ccc;
+}
+
+.zone {
+  flex: 1;
+  position: relative;
+  transition: background-color 0.3s, outline 0.3s;
+}
+
+.off {
+  background: #e0e0e0;
+}
+
+.cooling {
+  background: #4aa8ff;
+}
+
+.heating {
+  background: #ff6b6b;
+}
+
+.editing {
+  outline: 3px solid #ffd700;
+}
+
+.selected {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 12px;
+  padding: 2px 4px;
+  border-radius: 3px;
+}

--- a/src/components/BedDualZone.tsx
+++ b/src/components/BedDualZone.tsx
@@ -1,0 +1,50 @@
+/**
+ * BedDualZone renders a bed split into left and right zones.
+ * Each zone can be off, cooling, or heating. The component highlights
+ * the zone currently being edited and shows which zone is selected.
+ */
+import React from "react";
+import styles from "./BedDualZone.module.css";
+
+export type ZoneStatus = "off" | "cooling" | "heating";
+
+export interface BedDualZoneProps {
+  leftStatus: ZoneStatus;
+  rightStatus: ZoneStatus;
+  selectedSide?: "left" | "right";
+  editingSide?: "left" | "right";
+}
+
+export default function BedDualZone({
+  leftStatus,
+  rightStatus,
+  selectedSide,
+  editingSide,
+}: BedDualZoneProps) {
+  return (
+    <div className={styles.bed}>
+      <div
+        className={[
+          styles.zone,
+          styles[leftStatus],
+          editingSide === "left" ? styles.editing : "",
+        ].join(" ")}
+      >
+        {selectedSide === "left" && (
+          <span className={styles.selected}>✓</span>
+        )}
+      </div>
+      <div
+        className={[
+          styles.zone,
+          styles[rightStatus],
+          editingSide === "right" ? styles.editing : "",
+        ].join(" ")}
+      >
+        {selectedSide === "right" && (
+          <span className={styles.selected}>✓</span>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `BedDualZone` component to represent left and right bed zones with cooling, heating, and off states
- style zones with color coding, editing highlight, and selected markers
- showcase the new component on the home page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a836a082ec832fabc22d3b84bea1d5