### PR TITLE
Refine bed zone labels and schedule controls

### DIFF
--- a/src/components/BedDemo.tsx
+++ b/src/components/BedDemo.tsx
@@ -1,9 +1,26 @@
 'use client';
 
 import * as React from 'react';
-import { Stack, Button, Tabs, Tab, FormControlLabel, Switch } from '@mui/material';
+import {
+  Stack,
+  Tabs,
+  Tab,
+  FormControlLabel,
+  Switch,
+  IconButton,
+  Typography,
+  AppBar,
+  BottomNavigation,
+  BottomNavigationAction,
+  TextField,
+} from '@mui/material';
 import { BedDualZone, ZoneState } from './BedDualZone';
+import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
+import HomeIcon from '@mui/icons-material/Home';
+import SettingsIcon from '@mui/icons-material/Settings';
+import ScheduleIcon from '@mui/icons-material/Schedule';
 import { ColorModeContext } from '@/theme';
+import { TemperatureCarousel } from './TemperatureCarousel';
 
 type Side = 'left' | 'right';
 
@@ -13,73 +30,198 @@ export default function BedDemo() {
       mode: 'cool',
       currentTemp: 72,
       targetTemp: 68,
-      schedule: { running: false, nextStart: '22:00' },
+      schedule: { running: false },
     },
     right: {
       mode: 'off',
       currentTemp: 70,
+      schedule: { running: false },
     },
   });
   const [editing, setEditing] = React.useState<Side>('left');
+  const [unit, setUnit] = React.useState<'F' | 'C'>('F');
+  const [page, setPage] = React.useState<'home' | 'settings' | 'schedule'>('home');
+  const [sideNames, setSideNames] = React.useState<{ left: string; right: string }>({
+    left: 'Left',
+    right: 'Right',
+  });
 
   const updateZone = (side: Side, updater: (z: ZoneState) => ZoneState) =>
     setZones((z) => ({ ...z, [side]: updater(z[side]) }));
 
-  const cycle = (z: ZoneState): ZoneState => {
-    const nextMode = z.mode === 'cool' ? 'heat' : z.mode === 'heat' ? 'off' : 'cool';
-    const targetTemp =
-      nextMode === 'cool' ? z.currentTemp - 4 : nextMode === 'heat' ? z.currentTemp + 4 : undefined;
-    return { ...z, mode: nextMode, targetTemp };
-  };
+  const fToC = (f: number) => ((f - 32) * 5) / 9;
+  const cToF = (c: number) => (c * 9) / 5 + 32;
+  const toUnit = (t: number) => (unit === 'C' ? Math.round(fToC(t) * 10) / 10 : Math.round(t));
+  const fromUnit = (t: number) => (unit === 'C' ? cToF(t) : t);
 
-  const adjustTemp = (side: Side, delta: number) =>
-    updateZone(side, (z) => ({ ...z, currentTemp: z.currentTemp + delta }));
+  const tempCfg = unit === 'C'
+    ? { min: 13, max: 43.5, mid: 28, step: 0.5 }
+    : { min: 55, max: 110, mid: 82, step: 1 };
 
-  const toggleSchedule = (side: Side) =>
-    updateZone(side, (z) =>
-      z.schedule?.running
-        ? { ...z, schedule: { running: false, nextStart: '22:00' } }
-        : { ...z, schedule: { running: true } },
-    );
+  const setTemp = (side: Side, next: number) =>
+    updateZone(side, (z) => {
+      const clamped = Math.min(tempCfg.max, Math.max(tempCfg.min, next));
+      const nextF = fromUnit(clamped);
+      const mode =
+        z.mode === 'off'
+          ? z.mode
+          : nextF > z.currentTemp
+          ? 'heat'
+          : nextF < z.currentTemp
+          ? 'cool'
+          : z.mode;
+      return { ...z, targetTemp: nextF, mode };
+    });
+
+  const togglePower = (side: Side) =>
+    updateZone(side, (z) => {
+      if (z.mode === 'off') {
+        const target = z.targetTemp ?? z.currentTemp;
+        const mode =
+          target > z.currentTemp ? 'heat' : target < z.currentTemp ? 'cool' : 'heat';
+        return { ...z, mode, targetTemp: target };
+      }
+      return { ...z, mode: 'off' };
+    });
+
+  const toggleSchedule = (side: Side, running: boolean) =>
+    updateZone(side, (z) => ({ ...z, schedule: { ...z.schedule, running } }));
+
+  const setScheduleStart = (side: Side, nextStart: string) =>
+    updateZone(side, (z) => ({ ...z, schedule: { ...z.schedule, nextStart } }));
 
   const { mode, toggleMode } = React.useContext(ColorModeContext);
 
+  const pageTitle = page === 'home' ? 'Home' : page === 'settings' ? 'Settings' : 'Schedule';
+
   return (
-    <Stack
-      spacing={2}
-      sx={{ p: 2, maxWidth: 360, mx: 'auto', height: '100vh', justifyContent: 'center' }}
-    >
-      <FormControlLabel
-        control={<Switch checked={mode === 'dark'} onChange={() => toggleMode()} />}
-        label="Dark mode"
-        sx={{ alignSelf: 'flex-end', mr: 0 }}
-      />
-      <BedDualZone
-        left={zones.left}
-        right={zones.right}
-        editingSide={editing}
-        onSideClick={(s) => setEditing(s)}
-        labels={{ left: 'Left', right: 'Right' }}
-        width={360}
-      />
+    <>
+      <Typography variant="h6" align="center" sx={{ mt: 1 }}>
+        {pageTitle}
+      </Typography>
+      {page === 'home' ? (
+        <Stack
+          spacing={2}
+          sx={{ p: 2, maxWidth: 360, mx: 'auto', minHeight: 'calc(100vh - 56px)', pb: 7, alignItems: 'center' }}
+        >
+          <BedDualZone
+            left={zones.left}
+            right={zones.right}
+            editingSide={editing}
+            onSideClick={(s) => setEditing(s)}
+            width={360}
+            unit={unit}
+            sideNames={sideNames}
+          />
 
-      <Tabs
-        value={editing}
-        onChange={(_, v) => v && setEditing(v)}
-        aria-label="bed side controls"
-        textColor="secondary"
-        indicatorColor="secondary"
-      >
-        <Tab label="Left" value="left" />
-        <Tab label="Right" value="right" />
-      </Tabs>
+          <Tabs
+            value={editing}
+            onChange={(_, v) => v && setEditing(v)}
+            aria-label="bed side controls"
+            textColor="secondary"
+            indicatorColor="secondary"
+          >
+            <Tab label={sideNames.left} value="left" />
+            <Tab label={sideNames.right} value="right" />
+          </Tabs>
 
-      <Stack direction="row" spacing={1}>
-        <Button onClick={() => updateZone(editing, cycle)}>Cycle Mode</Button>
-        <Button onClick={() => adjustTemp(editing, 1)}>Temp +</Button>
-        <Button onClick={() => adjustTemp(editing, -1)}>Temp -</Button>
-        <Button onClick={() => toggleSchedule(editing)}>Toggle Schedule</Button>
-      </Stack>
-    </Stack>
+          {(() => {
+            const z = zones[editing];
+            const target = toUnit(z.targetTemp ?? fromUnit(tempCfg.mid));
+            return (
+              <Stack spacing={1} alignItems="center">
+                <IconButton
+                  color={z.mode === 'off' ? 'default' : 'secondary'}
+                  onClick={() => togglePower(editing)}
+                >
+                  <PowerSettingsNewIcon />
+                </IconButton>
+                <TemperatureCarousel
+                  value={target}
+                  onChange={(v) => setTemp(editing, v)}
+                  min={tempCfg.min}
+                  max={tempCfg.max}
+                  step={tempCfg.step}
+                  unit={unit}
+                />
+              </Stack>
+            );
+          })()}
+        </Stack>
+      ) : page === 'settings' ? (
+        <Stack
+          spacing={2}
+          sx={{ p: 2, maxWidth: 360, mx: 'auto', minHeight: 'calc(100vh - 56px)', pb: 7 }}
+        >
+          <FormControlLabel
+            control={<Switch checked={mode === 'dark'} onChange={() => toggleMode()} />}
+            label="Dark mode"
+          />
+          <FormControlLabel
+            control={<Switch checked={unit === 'C'} onChange={(e) => setUnit(e.target.checked ? 'C' : 'F')} />}
+            label="Show °C"
+          />
+          <TextField
+            label="Left name"
+            value={sideNames.left}
+            onChange={(e) => setSideNames((n) => ({ ...n, left: e.target.value }))}
+          />
+          <TextField
+            label="Right name"
+            value={sideNames.right}
+            onChange={(e) => setSideNames((n) => ({ ...n, right: e.target.value }))}
+          />
+        </Stack>
+      ) : (
+        <Stack
+          spacing={2}
+          sx={{ p: 2, maxWidth: 360, mx: 'auto', minHeight: 'calc(100vh - 56px)', pb: 7, alignItems: 'center' }}
+        >
+          <BedDualZone
+            left={zones.left}
+            right={zones.right}
+            editingSide={editing}
+            onSideClick={(s) => setEditing(s)}
+            width={360}
+            unit={unit}
+            sideNames={sideNames}
+          />
+
+          <Tabs
+            value={editing}
+            onChange={(_, v) => v && setEditing(v)}
+            aria-label="schedule controls"
+            textColor="secondary"
+            indicatorColor="secondary"
+          >
+            <Tab label={sideNames.left} value="left" />
+            <Tab label={sideNames.right} value="right" />
+          </Tabs>
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={!!zones[editing].schedule?.running}
+                onChange={(e) => toggleSchedule(editing, e.target.checked)}
+              />
+            }
+            label="Schedule running"
+          />
+
+          <TextField
+            label="Starts at"
+            value={zones[editing].schedule?.nextStart ?? ''}
+            onChange={(e) => setScheduleStart(editing, e.target.value)}
+          />
+        </Stack>
+      )}
+      <AppBar position="fixed" color="primary" sx={{ top: 'auto', bottom: 0 }}>
+        <BottomNavigation showLabels value={page} onChange={(_, v) => setPage(v)}>
+          <BottomNavigationAction label="Home" value="home" icon={<HomeIcon />} />
+          <BottomNavigationAction label="Schedule" value="schedule" icon={<ScheduleIcon />} />
+          <BottomNavigationAction label="Settings" value="settings" icon={<SettingsIcon />} />
+        </BottomNavigation>
+      </AppBar>
+    </>
   );
 }

--- a/src/components/TemperatureCarousel.tsx
+++ b/src/components/TemperatureCarousel.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Stack, Tabs, Tab, IconButton } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
+
+interface TemperatureCarouselProps {
+  value: number;
+  onChange: (value: number) => void;
+  min: number;
+  max: number;
+  step: number;
+  unit: 'F' | 'C';
+}
+
+export function TemperatureCarousel({ value, onChange, min, max, step, unit }: TemperatureCarouselProps) {
+  const values = React.useMemo(() => {
+    const arr: number[] = [];
+    for (let v = min; v <= max + step / 2; v += step) {
+      arr.push(Math.round(v * 10) / 10);
+    }
+    return arr;
+  }, [min, max, step]);
+
+  const clamp = (v: number) => Math.min(max, Math.max(min, v));
+
+  return (
+    <Stack direction="row" spacing={1} alignItems="center" sx={{ width: '100%' }}>
+      <IconButton onClick={() => onChange(clamp(value - step))}>
+        <RemoveIcon />
+      </IconButton>
+      <Tabs
+        value={value}
+        onChange={(_, newValue) => onChange(newValue)}
+        variant="scrollable"
+        scrollButtons="auto"
+        allowScrollButtonsMobile
+        sx={{ flex: 1, minHeight: 48 }}
+      >
+        {values.map((v) => (
+          <Tab key={v} value={v} label={`${v}°${unit}`} sx={{ minHeight: 48 }} />
+        ))}
+      </Tabs>
+      <IconButton onClick={() => onChange(clamp(value + step))}>
+        <AddIcon />
+      </IconButton>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- Move each side's label to the top of its zone and drop redundant status text
- Show "Maintaining" when current and target temperatures match
- Allow zones to be powered on at midpoint and preserve mode when target equals current
- Add schedule controls to toggle running and set a future start time
- Keep the pillow visible when selecting a side by layering it above the zone highlight
- Introduce a scrollable temperature carousel with +/- buttons for faster adjustments

## Testing
- ⚠️ `npm test` (Missing script: "test")
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a864944c20832f8d3ef97e0f641b4f