### PR TITLE
Display decimal temperatures in bed zones

### DIFF
--- a/src/components/BedDemo.tsx
+++ b/src/components/BedDemo.tsx
@@ -51,7 +51,8 @@ export default function BedDemo() {
 
   const fToC = (f: number) => ((f - 32) * 5) / 9;
   const cToF = (c: number) => (c * 9) / 5 + 32;
-  const toUnit = (t: number) => (unit === 'C' ? Math.round(fToC(t) * 10) / 10 : Math.round(t));
+  const toUnit = (t: number) =>
+    unit === 'C' ? Math.round(fToC(t) * 2) / 2 : Math.round(t);
   const fromUnit = (t: number) => (unit === 'C' ? cToF(t) : t);
 
   const tempCfg = unit === 'C'

--- a/src/components/BedDualZone.tsx
+++ b/src/components/BedDualZone.tsx
@@ -137,7 +137,7 @@ export function BedDualZone({
 
   const formatTemp = (t: number) =>
     unit === 'C'
-      ? Math.round(((t - 32) * 5) / 9 * 10) / 10
+      ? Math.round(((t - 32) * 5) / 9 * 2) / 2
       : Math.round(t * 10) / 10;
 
   const unitLabel = `°${unit}`;

--- a/src/components/BedDualZone.tsx
+++ b/src/components/BedDualZone.tsx
@@ -136,7 +136,9 @@ export function BedDualZone({
   } as const;
 
   const formatTemp = (t: number) =>
-    unit === 'C' ? Math.round(((t - 32) * 5) / 9) : Math.round(t);
+    unit === 'C'
+      ? Math.round(((t - 32) * 5) / 9 * 10) / 10
+      : Math.round(t * 10) / 10;
 
   const unitLabel = `°${unit}`;
 


### PR DESCRIPTION
## Summary
- Preserve fractional temperatures when formatting to show decimals

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a89a206464832f97b64b61aa98dc7c