### PR TITLE
refactor: centralize temperature utilities

### DIFF
--- a/src/components/BedDemo.tsx
+++ b/src/components/BedDemo.tsx
@@ -21,6 +21,7 @@ import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
 import HomeIcon from '@mui/icons-material/Home';
 import SettingsIcon from '@mui/icons-material/Settings';
 import ScheduleIcon from '@mui/icons-material/Schedule';
+import { toUnit, fromUnit } from '@/utils/temperature';
 
 type Side = 'left' | 'right';
 
@@ -49,22 +50,16 @@ export default function BedDemo() {
   const updateZone = (side: Side, updater: (z: ZoneState) => ZoneState) =>
     setZones((z) => ({ ...z, [side]: updater(z[side]) }));
 
-  const fToC = (f: number) => ((f - 32) * 5) / 9;
-  const cToF = (c: number) => (c * 9) / 5 + 32;
-  const toUnit = (t: number) =>
-    unit === 'C' ? Math.round(fToC(t) * 2) / 2 : Math.round(t);
-  const fromUnit = (t: number) => (unit === 'C' ? cToF(t) : t);
-
   const tempCfg = unit === 'C'
     ? { min: 13, max: 43.5, mid: 28, step: 0.5 }
     : { min: 55, max: 110, mid: 82, step: 1 };
 
   const changeTemp = (side: Side, delta: number) =>
     updateZone(side, (z) => {
-      const currentTarget = toUnit(z.targetTemp ?? fromUnit(tempCfg.mid));
+      const currentTarget = toUnit(z.targetTemp ?? fromUnit(tempCfg.mid, unit), unit);
       let next = currentTarget + delta;
       next = Math.min(tempCfg.max, Math.max(tempCfg.min, next));
-      const nextF = fromUnit(next);
+      const nextF = fromUnit(next, unit);
       const mode =
         z.mode === 'off'
           ? z.mode
@@ -132,7 +127,7 @@ export default function BedDemo() {
 
           {(() => {
             const z = zones[editing];
-            const target = toUnit(z.targetTemp ?? fromUnit(tempCfg.mid));
+            const target = toUnit(z.targetTemp ?? fromUnit(tempCfg.mid, unit), unit);
             return (
               <Stack spacing={1} alignItems="center">
                 <IconButton

--- a/src/components/BedDualZone.tsx
+++ b/src/components/BedDualZone.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { Box, ButtonBase, Typography } from '@mui/material';
 import { alpha, useTheme, SxProps, Theme } from '@mui/material/styles';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import { formatTemp } from '@/utils/temperature';
 
 type Side = 'left' | 'right';
 type Mode = 'off' | 'cool' | 'heat';
@@ -134,11 +135,6 @@ export function BedDualZone({
     },
     zIndex: 2,
   } as const;
-
-  const formatTemp = (t: number) =>
-    unit === 'C'
-      ? Math.round(((t - 32) * 5) / 9 * 2) / 2
-      : Math.round(t * 10) / 10;
 
   const unitLabel = `°${unit}`;
 
@@ -284,7 +280,7 @@ export function BedDualZone({
                   textShadow: '0 1px 2px rgba(0,0,0,0.6)',
                 }}
               >
-                {formatTemp(state.currentTemp)}{unitLabel}
+                {formatTemp(state.currentTemp, unit)}{unitLabel}
               </Typography>
 
               {state.mode !== 'off' && state.targetTemp !== undefined && (
@@ -301,9 +297,10 @@ export function BedDualZone({
                   }}
                 >
                   {state.currentTemp === state.targetTemp
-                    ? `Maintaining ${formatTemp(state.targetTemp)}${unitLabel}`
+                    ? `Maintaining ${formatTemp(state.targetTemp, unit)}${unitLabel}`
                     : `${state.mode === 'cool' ? 'Cooling to' : 'Heating to'} ${formatTemp(
                         state.targetTemp,
+                        unit,
                       )}${unitLabel}`}
                 </Typography>
               )}

--- a/src/utils/temperature.ts
+++ b/src/utils/temperature.ts
@@ -1,0 +1,26 @@
+export type TempUnit = 'F' | 'C';
+
+/** Convert Fahrenheit to Celsius. */
+export const fToC = (f: number): number => ((f - 32) * 5) / 9;
+
+/** Convert Celsius to Fahrenheit. */
+export const cToF = (c: number): number => (c * 9) / 5 + 32;
+
+/**
+ * Convert a temperature from stored Fahrenheit to the display unit.
+ * Fahrenheit values are rounded to whole numbers, Celsius to halves.
+ */
+export const toUnit = (tempF: number, unit: TempUnit): number =>
+  unit === 'C' ? Math.round(fToC(tempF) * 2) / 2 : Math.round(tempF);
+
+/** Convert a value from the display unit back to Fahrenheit. */
+export const fromUnit = (temp: number, unit: TempUnit): number =>
+  unit === 'C' ? cToF(temp) : temp;
+
+/**
+ * Format a Fahrenheit temperature for display in the selected unit.
+ * Fahrenheit is shown with one decimal precision, Celsius with half degrees.
+ */
+export const formatTemp = (tempF: number, unit: TempUnit): number =>
+  unit === 'C' ? Math.round(fToC(tempF) * 2) / 2 : Math.round(tempF * 10) / 10;
+


### PR DESCRIPTION
## Summary
- extract reusable temperature conversion helpers
- reuse shared helpers in BedDemo and BedDualZone

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a89d6ffa54832fba7c9f18e466231d